### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/tp1de/ioBroker.ems-esp/issues"
   },
   "bundleDependencies": [],
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "buffer": "^6.0.3",


### PR DESCRIPTION
adapter-code 3.x.x is known to fail during installation with node 14 or lower due to npm 6 not installing peerDependencies.
So this adapter should require node 16 or newer.

Please increment minor version number for next release due to node requirement change ('best praxis')