### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "bundleDependencies": [],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
Youre github tests have been rstricted to node 18 and 20. So this adapter MUST either rquire node 18 minimum (as done with this PR) OR you must (re)add node 16 tests to standard test-and-release workflow.

Do not forget to add a note to the README.md indicating node 18 requirement if you merge this PR.

Note: seesm to be relevang for 3.x.x and later only