### PR TITLE
Fix for "private_pw" not listed at "protectedNative" and "encryptedNative"

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -168,12 +168,6 @@
         "admin": ">=6.13.16"
       }
     ],
-    "encryptedNative": [
-      "private_pw"
-    ],
-    "protectedNative": [
-      "private_pw"
-    ],
     "messages": [
       {
         "condition": {
@@ -217,6 +211,12 @@
       }
     ]
   },
+  "encryptedNative": [
+    "private_pw"
+  ],
+  "protectedNative": [
+    "private_pw"
+  ],
   "native": {
     "private_pw": "",
     "control_file": "*",


### PR DESCRIPTION
#134 - Es war nur an der falschen Stelle.